### PR TITLE
Add upload diagnostics and fallback for Cloudflare direct upload

### DIFF
--- a/src/pages/DecodePage.tsx
+++ b/src/pages/DecodePage.tsx
@@ -111,6 +111,7 @@ export function DecodePage() {
         cfImageId: imageId,
         uploadURLHost: new URL(uploadURL).host,
       });
+      console.log('[upload] about to POST to CF', { hasURL: !!uploadURL, host: new URL(uploadURL).host });
       const uploadResult = await uploadToCloudflare(uploadURL, file, setUploadProgress, controller.signal);
       if (!uploadResult.success) throw new Error(uploadResult.error || 'Upload to Cloudflare failed');
       await markIngestComplete(assetId, imageId);
@@ -122,7 +123,7 @@ export function DecodePage() {
       toast.success('Image uploaded and verified successfully');
 
     } catch (error: any) {
-      console.error('[upload] Upload failed:', error);
+      console.error('[upload] failed', { error, stack: error?.stack });
       
       if (error.message === 'Upload cancelled') {
         toast.info('Upload cancelled');


### PR DESCRIPTION
## Summary
- add global upload debug helper and harden direct upload response parsing
- instrument Cloudflare upload with XHR lifecycle logging and fetch fallback
- add Decode page breadcrumbs for Cloudflare POST attempts and failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24e9169f48325a490a472a8aa96a5