### PR TITLE
Add worker route for creating posts

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -8,6 +8,7 @@ import { decode } from './routes/decode';
 import { publish } from './routes/publish';
 import { srefUpload, srefUnlock } from './routes/sref';
 import { search } from './routes/search';
+import { createPost } from './routes/posts';
 
 function generateReqId(): string {
   return Math.random().toString(36).slice(2, 10);
@@ -46,6 +47,8 @@ export default {
         response = allowOrigin(env, req, await ensureVariants(env, req));
       } else if (cleanPath === '/v1/decode' && req.method==='POST') {
         response = allowOrigin(env, req, await decode(env, req, reqId));
+      } else if (cleanPath === '/v1/posts/create' && req.method==='POST') {
+        response = allowOrigin(env, req, await createPost(env, req, reqId));
       } else if (cleanPath === '/v1/publish' && req.method==='POST') {
         response = allowOrigin(env, req, await publish(env, req));
       } else if (cleanPath === '/v1/sref/upload' && req.method==='POST') {

--- a/src/worker/routes/posts.ts
+++ b/src/worker/routes/posts.ts
@@ -1,0 +1,45 @@
+import { json, bad } from '../lib/json';
+import { requireUser, getAuthedClient } from '../lib/auth';
+import type { Env } from '../types';
+
+export async function createPost(env: Env, req: Request, reqId?: string) {
+  const logPrefix = reqId ? `[${reqId}] [posts]` : '[posts]';
+
+  try {
+    const { user, token } = await requireUser(env, req, reqId);
+    const body = await req.json();
+
+    const { analysis, imageBase64, model } = body || {};
+    if (!analysis || !imageBase64) {
+      return bad('Missing analysis or imageBase64', 400);
+    }
+
+    const client = getAuthedClient(env, token);
+
+    const { data: post, error } = await client
+      .from('posts')
+      .insert({
+        user_id: user.id,
+        model,
+        analysis,
+        image_base64: imageBase64,
+        created_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error(`${logPrefix} insert failed:`, error);
+      return bad('Failed to insert post', 500);
+    }
+
+    console.log(`${logPrefix} created post id=${post.id}`);
+    return json({ ok: true, postId: post.id });
+  } catch (err) {
+    if (err instanceof Response) {
+      return err;
+    }
+    console.error(`${logPrefix} error:`, err);
+    return bad('Internal error', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- add a posts route that validates input, uses the authed client, and inserts into Supabase
- register the /v1/posts/create endpoint with the worker router

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e259bef3c8832585e9d5a6f09191b3