### PR TITLE
Refactor decode flow to use new analysis pipeline

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -87,7 +87,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return false;
       }
 
-      const response = await api.post('/ensure-account');
+      const response = await api.post('/v1/ensure-account');
 
       if (!response.ok) {
         console.warn('[Auth] ensure_account endpoint error:', { error: response.error, retryCount });
@@ -149,7 +149,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return { tokens_balance: 0, plan_name: 'free' };
       }
 
-      const response = await api.get('/balance');
+      const response = await api.get('/v1/balance');
 
       if (!response.ok) {
         console.warn('[Auth] get_balance endpoint error:', { error: response.error, retryCount });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 import { supabase } from './supabase';
 
-// API base URL - always use https://aikizi.xyz/v1 for production
-const API_BASE = 'https://aikizi.xyz/v1';
+// API base URL - always use https://aikizi.xyz for production
+const API_BASE = 'https://aikizi.xyz';
 
 export interface ApiError {
   ok: false;
@@ -55,7 +55,7 @@ export async function apiCall<T = unknown>(
     }
 
     const url = `${API_BASE}${endpoint}`;
-    const timeout = endpoint.startsWith('/decode') ? 60000 : 15000;
+    const timeout = endpoint.startsWith('/v1/decode') ? 60000 : 15000;
 
     console.log('[API]', options.method || 'GET', url, { hasToken: true, timeout });
 
@@ -158,20 +158,8 @@ export const api = {
     apiCall<T>(endpoint, { ...options, method: 'DELETE' }),
 };
 
-export interface DecodeImagePayload {
-  image_base64: string;
-  model?: string;
-  mime_type?: string;
-}
+export const decodeImage = <T = unknown>(model: string, image_base64: string, user_id: string) =>
+  api.post<T>(`/v1/decode/${model}`, { image_base64, user_id, model });
 
-export interface CreatePostPayload {
-  analysis: unknown;
-  image_base64: string;
-  model: string;
-}
-
-export const decodeImage = <T = unknown>(model: string, payload: DecodeImagePayload) =>
-  api.post<T>(`/decode/${model}`, { ...payload, model });
-
-export const createPostRecord = <T = unknown>(payload: CreatePostPayload) =>
-  api.post<T>('/posts/create', payload);
+export const createPost = <T = unknown>(model: string, image_base64: string, analysis: unknown) =>
+  api.post<T>('/v1/posts/create', { model, image_base64, analysis });

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -129,7 +129,7 @@ export function PostDetailPage() {
         return;
       }
 
-      const response = await api.post('/sref/unlock', {
+      const response = await api.post('/v1/sref/unlock', {
         post_id: postId,
       });
 

--- a/src/worker/routes/decode.ts
+++ b/src/worker/routes/decode.ts
@@ -9,6 +9,7 @@ interface DecodeBody {
   image_base64?: string;
   model?: string;
   mime_type?: string;
+  user_id?: string;
 }
 
 interface AnalysisPayload {
@@ -86,6 +87,10 @@ export async function decode(env: Env, req: Request, modelParam: string, reqId?:
     console.log(`${logPrefix} Invalid JSON`);
     await refundToken(dbClient, userData.id, logPrefix);
     return cors(json({ success: false, error: 'invalid input' }, 422));
+  }
+
+  if (body.user_id && body.user_id !== user.id) {
+    console.warn(`${logPrefix} user_id mismatch body=${body.user_id} auth=${user.id}`);
   }
 
   const rawBase64 = typeof body.image_base64 === 'string' ? body.image_base64.trim() : '';

--- a/src/worker/routes/posts.ts
+++ b/src/worker/routes/posts.ts
@@ -1,12 +1,13 @@
 import { json, bad } from '../lib/json';
-import { requireUser, getAuthedClient } from '../lib/auth';
+import { requireUser } from '../lib/auth';
+import { supa } from '../lib/supa';
 import type { Env } from '../types';
 
 export async function createPost(env: Env, req: Request, reqId?: string) {
   const logPrefix = reqId ? `[${reqId}] [posts]` : '[posts]';
 
   try {
-    const { user, token } = await requireUser(env, req, reqId);
+    const { user } = await requireUser(env, req, reqId);
     const body = await req.json();
 
     const { analysis, image_base64, model } = body || {};
@@ -14,7 +15,7 @@ export async function createPost(env: Env, req: Request, reqId?: string) {
       return bad('Missing analysis, image_base64, or model', 400);
     }
 
-    const client = getAuthedClient(env, token);
+    const client = supa(env);
 
     const sanitizedImage = image_base64.trim();
     if (!sanitizedImage) {


### PR DESCRIPTION
## Summary
- update the API client to target the new `/v1` endpoints and expose helpers for decoding images and creating posts
- refactor the Decode page to read uploads as Base64, call the synchronous decode API, and post analyses directly to Supabase
- adjust worker routes to accept the `user_id` field on decode and create posts with the service key for the new posts table

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e262b1adf883259b0df1134054f1e4