### PR TITLE
Refactor decode upload flow to use decode/posts pipeline

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -60,28 +60,6 @@ export default {
         response = await createPost(env, req, reqId);
       } else if (cleanPath === '/v1/balance' && method === 'POST') {
         response = json({ ok: false, error: 'method_not_allowed' }, 405);
-      } else if (cleanPath === '/v1/images/direct-upload' && method === 'POST') {
-        // TODO: remove after frontend purge
-        console.warn('[compat] legacy upload route hit', { path: cleanPath, reqId });
-        response = json(
-          {
-            ok: false,
-            error: 'legacy_route_removed',
-            hint: 'Send base64 to /v1/decode/<model> then POST /v1/posts/create',
-          },
-          410,
-        );
-      } else if (cleanPath === '/v1/images/ingest-complete' && method === 'POST') {
-        // TODO: remove after frontend purge
-        console.warn('[compat] legacy upload route hit', { path: cleanPath, reqId });
-        response = json(
-          {
-            ok: false,
-            error: 'legacy_route_removed',
-            hint: 'Send base64 to /v1/decode/<model> then POST /v1/posts/create',
-          },
-          410,
-        );
       } else if (cleanPath === '/v1/publish' && method === 'POST') {
         response = await publish(env, req);
       } else if (cleanPath === '/v1/sref/upload' && method === 'POST') {


### PR DESCRIPTION
## Summary
- refactor the Decode page to convert uploads to base64, call the decode API, and automatically create posts
- update the API helper to pass mime types to /v1/decode and warn when any legacy /v1/images route is used
- remove the deprecated Cloudflare image endpoints from the worker router

## Testing
- npm run lint *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a715fe68832589dcc990c738ed9a